### PR TITLE
Rename crate to follow the new repo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "efm32hg309f64-pac"
+name = "efm32hg-pac"
 version = "0.1.0"
 authors = ["Jacob Rosenthal <jacobrosenthal@gmail.com>"]
 edition = "2018"
 keywords = ["no-std", "arm", "cortex-m", "efm32", "efm32hg", "efm32hg309", "efm32hg309f64", "pac"]
 readme = "readme.md"
-repository = "https://github.com/jacobrosenthal/efm32hg309f64-pac"
+repository = "https://github.com/em32-rs/efm32hg-pac"
 
 [dependencies]
 bare-metal = "0.2.0"

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,17 @@
-# `efm32hg309f64-pac`
+# `efm32hg-pac`
 
-Peripheral access API for efm32hg309f64 microcontroller from Silicon Labs.
+Peripheral access API for efm32hg microcontroller from Silicon Labs.
 
-The efm32hg309f64 register definitions were retrieved from from keil.com and provided here in ./svd as a convenience only.
+The efm32hg register definitions were retrieved from from keil.com and provided here in ./svd as a convenience only.
 
-## [Documentation](https://docs.rs/efm32hg309f64-pac)
+## Supported Series
+Currently supported and tested series:
+
+- efm32hg309f64
+
+Other HG series might be able to use this crate but is not supported until it's stated otherwise.
+
+## [Documentation](https://docs.rs/efm32hg-pac)
 
 ## Requirements
 The crate can be used with Rust v1.31 or newer. However `cargo gen` will require Rust nightly due to its `rustfmt-nightly` dependency.


### PR DESCRIPTION
Wondering if it's ok to rename right now. I'm currently trying to add support for efm32hg on top of @chrysn efm32gg-hal, will need to import this crate.