### PR TITLE
patch ripgrep ignore

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,7 @@ rt = ["cortex-m-rt/device"]
 
 [workspace]
 members = ["tools"]
+
+# https://github.com/BurntSushi/ripgrep/issues/1423
+[replace]
+"ignore:0.4.10" = { git = "https://github.com/ctaggart/ripgrep", package = "ignore", rev = "8f961df" }


### PR DESCRIPTION
Been seeing this for month+ and ignore hasnt moved yet.
rustfmt broken https://github.com/crossbeam-rs/crossbeam/issues/435, need rustfmt to update crossbeam-channel to  0.4
"Unfortunately it seems that ignore is pinned on crossbeam-channel v0.3.6 which in turn has a ^v0.6.5 dependency on crossbeam-utils, basically preventing updating either"

We dont need to merge this until we need to regenerate or release, maybe by then theyll have bumped that dep finally.